### PR TITLE
Stop outputting stack trace when killing GAE

### DIFF
--- a/bin/technicolor-yawn
+++ b/bin/technicolor-yawn
@@ -35,10 +35,10 @@ def format_line(parsed_line):
             'ERROR': 'red',
             'CRITICAL': 'magenta',
         },
-        'date': 'white',
-        'time': 'white',
-        'filename': 'white',
-        'line': 'cyan',
+        'date': 'grey',
+        'time': 'grey',
+        'filename': 'grey',
+        'line': 'grey',
         'message': 'white'
     }
 


### PR DESCRIPTION
There's no reason to output the stack trace since this is the "accepted" way of killing GAE from the console.  At least, that's what I do.
