### PR TITLE
Fix last line not being flushed

### DIFF
--- a/bin/technicolor-yawn
+++ b/bin/technicolor-yawn
@@ -96,6 +96,12 @@ def read_file(fileobj):
                 if message_buffer:
                     output_log(message_buffer)
                 message_buffer = [message_start_match]
+
+                # If the line is complete, immediately flush it
+                if line.endswith("\n"):
+                    output_log(message_buffer)
+                    message_buffer = []
+
             elif message_buffer:
                 message_buffer.append(line)
             else:


### PR DESCRIPTION
When piping output to technicolor-yawn, the last line always remains buffered. This is a suggestion for a fix.

PS: You don't notice it when running on the test file, because of the `finally` line in `read_file`. If you remove it (which resembles the piping case more accurately), you'll also see the last line missing.